### PR TITLE
Parallelize fitness calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/settings.json

--- a/pm4py/evaluation/precision/evaluator.py
+++ b/pm4py/evaluation/precision/evaluator.py
@@ -1,4 +1,4 @@
-'''
+"""
     This file is part of PM4Py (More Info: https://pm4py.fit.fraunhofer.de).
 
     PM4Py is free software: you can redistribute it and/or modify
@@ -13,7 +13,7 @@
 
     You should have received a copy of the GNU General Public License
     along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
-'''
+"""
 from pm4py.evaluation.precision.variants import etconformance_token, align_etconformance
 from pm4py.objects.conversion.log import converter as log_conversion
 from pm4py.objects.petri.check_soundness import check_easy_soundness_net_in_fin_marking
@@ -61,15 +61,15 @@ def apply(log, net, marking, final_marking, parameters=None, variant=None):
 
     # execute the following part of code when the variant is not specified by the user
     if variant is None:
-        if not (check_easy_soundness_net_in_fin_marking(
-                net,
-                marking,
-                final_marking)):
+        if not (check_easy_soundness_net_in_fin_marking(net, marking, final_marking)):
             # in the case the net is not a easy sound workflow net, we must apply token-based replay
+            print("DOING FIRST THING")
             variant = ETCONFORMANCE_TOKEN
         else:
+            print("DOING SECOND THING")
             # otherwise, use the align-etconformance approach (safer, in the case the model contains duplicates)
             variant = ALIGN_ETCONFORMANCE
 
-    return exec_utils.get_variant(variant).apply(log, net, marking,
-                             final_marking, parameters=parameters)
+    return exec_utils.get_variant(variant).apply(
+        log, net, marking, final_marking, parameters=parameters
+    )

--- a/pm4py/evaluation/precision/variants/align_etconformance.py
+++ b/pm4py/evaluation/precision/variants/align_etconformance.py
@@ -272,42 +272,6 @@ def align_fake_log_stop_marking(fake_log, net, marking, final_marking, parameter
             # replaying the given prefix, then add None
             align_result.append(None)
 
-    # for i in range(len(fake_log)):
-    #     trace = fake_log[i]
-    #     sync_net, sync_initial_marking, sync_final_marking = build_sync_net(
-    #         trace, net, marking, final_marking, parameters=parameters
-    #     )
-    #     stop_marking = Marking()
-    #     for pl, count in sync_final_marking.items():
-    #         if pl.name[1] == utils.SKIP:
-    #             stop_marking[pl] = count
-    #     cost_function = utils.construct_standard_cost_function(sync_net, utils.SKIP)
-
-    #     # perform the alignment of the prefix
-    #     res = precision_utils.__search(
-    #         sync_net,
-    #         sync_initial_marking,
-    #         sync_final_marking,
-    #         stop_marking,
-    #         cost_function,
-    #         utils.SKIP,
-    #     )
-
-    # if res is not None:
-    #     align_result.append([])
-    #     for mark in res:
-    #         res2 = {}
-    #         for pl in mark:
-    #             # transforms the markings for easier correspondence at the end
-    #             # (distributed engine friendly!)
-    #             res2[(pl.name[0], pl.name[1])] = mark[pl]
-
-    #         align_result[-1].append(res2)
-    # else:
-    #     # if there is no path from the initial marking
-    #     # replaying the given prefix, then add None
-    #     align_result.append(None)
-
     return align_result
 
 

--- a/pm4py/evaluation/precision/variants/align_etconformance.py
+++ b/pm4py/evaluation/precision/variants/align_etconformance.py
@@ -1,4 +1,4 @@
-'''
+"""
     This file is part of PM4Py (More Info: https://pm4py.fit.fraunhofer.de).
 
     PM4Py is free software: you can redistribute it and/or modify
@@ -13,7 +13,10 @@
 
     You should have received a copy of the GNU General Public License
     along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
-'''
+"""
+from multiprocessing import Pool
+from functools import partial
+import multiprocessing
 from pm4py.objects import log as log_lib
 from pm4py.evaluation.precision import utils as precision_utils
 from pm4py.objects.petri import align_utils as utils
@@ -22,7 +25,9 @@ from pm4py.objects.petri.petrinet import Marking
 from pm4py.objects.petri.utils import construct_trace_net
 from pm4py.objects.petri.synchronous_product import construct
 from pm4py.statistics.start_activities.log.get import get_start_activities
-from pm4py.objects.petri.align_utils import get_visible_transitions_eventually_enabled_by_marking
+from pm4py.objects.petri.align_utils import (
+    get_visible_transitions_eventually_enabled_by_marking,
+)
 from pm4py.evaluation.precision.parameters import Parameters
 from pm4py.util import exec_utils
 from pm4py.util import xes_constants
@@ -52,7 +57,9 @@ def apply(log, net, marking, final_marking, parameters=None):
 
     debug_level = parameters["debug_level"] if "debug_level" in parameters else 0
 
-    activity_key = exec_utils.get_param_value(Parameters.ACTIVITY_KEY, parameters, log_lib.util.xes.DEFAULT_NAME_KEY)
+    activity_key = exec_utils.get_param_value(
+        Parameters.ACTIVITY_KEY, parameters, log_lib.util.xes.DEFAULT_NAME_KEY
+    )
 
     # default value for precision, when no activated transitions (not even by looking at the initial marking) are found
     precision = 1.0
@@ -60,15 +67,25 @@ def apply(log, net, marking, final_marking, parameters=None):
     sum_at = 0
     unfit = 0
 
-    if not check_soundness.check_easy_soundness_net_in_fin_marking(net, marking, final_marking):
-        raise Exception("trying to apply Align-ETConformance on a Petri net that is not a easy sound net!!")
+    if not check_soundness.check_easy_soundness_net_in_fin_marking(
+        net, marking, final_marking
+    ):
+        raise Exception(
+            "trying to apply Align-ETConformance on a Petri net that is not a easy sound net!!"
+        )
 
-    prefixes, prefix_count = precision_utils.get_log_prefixes(log, activity_key=activity_key)
+    prefixes, prefix_count = precision_utils.get_log_prefixes(
+        log, activity_key=activity_key
+    )
     prefixes_keys = list(prefixes.keys())
     fake_log = precision_utils.form_fake_log(prefixes_keys, activity_key=activity_key)
 
-    align_stop_marking = align_fake_log_stop_marking(fake_log, net, marking, final_marking, parameters=parameters)
-    all_markings = transform_markings_from_sync_to_original_net(align_stop_marking, net, parameters=parameters)
+    align_stop_marking = align_fake_log_stop_marking(
+        fake_log, net, marking, final_marking, parameters=parameters
+    )
+    all_markings = transform_markings_from_sync_to_original_net(
+        align_stop_marking, net, parameters=parameters
+    )
 
     for i in range(len(prefixes)):
         markings = all_markings[i]
@@ -80,8 +97,12 @@ def apply(log, net, marking, final_marking, parameters=None):
                 # add to the set of activated transitions in the model the activated transitions
                 # for each prefix
                 activated_transitions_labels = activated_transitions_labels.union(
-                    x.label for x in utils.get_visible_transitions_eventually_enabled_by_marking(net, m) if
-                    x.label is not None)
+                    x.label
+                    for x in utils.get_visible_transitions_eventually_enabled_by_marking(
+                        net, m
+                    )
+                    if x.label is not None
+                )
             escaping_edges = activated_transitions_labels.difference(log_transitions)
 
             sum_at += len(activated_transitions_labels) * prefix_count[prefixes_keys[i]]
@@ -104,7 +125,12 @@ def apply(log, net, marking, final_marking, parameters=None):
 
     # fix: also the empty prefix should be counted!
     start_activities = set(get_start_activities(log, parameters=parameters))
-    trans_en_ini_marking = set([x.label for x in get_visible_transitions_eventually_enabled_by_marking(net, marking)])
+    trans_en_ini_marking = set(
+        [
+            x.label
+            for x in get_visible_transitions_eventually_enabled_by_marking(net, marking)
+        ]
+    )
     diff = trans_en_ini_marking.difference(start_activities)
     sum_at += len(log) * len(trans_en_ini_marking)
     sum_ee += len(log) * len(diff)
@@ -167,6 +193,28 @@ def transform_markings_from_sync_to_original_net(markings0, net, parameters=None
     return markings
 
 
+def wrapper(trace, net, marking, final_marking, parameters=None):
+    sync_net, sync_initial_marking, sync_final_marking = build_sync_net(
+        trace, net, marking, final_marking, parameters=parameters
+    )
+    stop_marking = Marking()
+    for pl, count in sync_final_marking.items():
+        if pl.name[1] == utils.SKIP:
+            stop_marking[pl] = count
+    cost_function = utils.construct_standard_cost_function(sync_net, utils.SKIP)
+
+    # perform the alignment of the prefix
+    res = precision_utils.__search(
+        sync_net,
+        sync_initial_marking,
+        sync_final_marking,
+        stop_marking,
+        cost_function,
+        utils.SKIP,
+    )
+    return res
+
+
 def align_fake_log_stop_marking(fake_log, net, marking, final_marking, parameters=None):
     """
     Align the 'fake' log with all the prefixes in order to get the markings in which
@@ -193,20 +241,21 @@ def align_fake_log_stop_marking(fake_log, net, marking, final_marking, parameter
     if parameters is None:
         parameters = {}
     align_result = []
-    for i in range(len(fake_log)):
-        trace = fake_log[i]
-        sync_net, sync_initial_marking, sync_final_marking = build_sync_net(trace, net, marking, final_marking,
-                                                                            parameters=parameters)
-        stop_marking = Marking()
-        for pl, count in sync_final_marking.items():
-            if pl.name[1] == utils.SKIP:
-                stop_marking[pl] = count
-        cost_function = utils.construct_standard_cost_function(sync_net, utils.SKIP)
+    print("OYOYoYOYoYoYOYO")
+    with Pool(processes=multiprocessing.cpu_count() - 7) as pool:
+        print("CPU COUNT: ", multiprocessing.cpu_count() - 7)
+        partial_func = partial(
+            wrapper,
+            net=net,
+            marking=marking,
+            final_marking=final_marking,
+            parameters=parameters,
+        )
+        result = pool.map(partial_func, fake_log)
+        pool.close()
+        pool.join()
 
-        # perform the alignment of the prefix
-        res = precision_utils.__search(sync_net, sync_initial_marking, sync_final_marking, stop_marking, cost_function,
-                                       utils.SKIP)
-
+    for res in result:
         if res is not None:
             align_result.append([])
             for mark in res:
@@ -221,6 +270,42 @@ def align_fake_log_stop_marking(fake_log, net, marking, final_marking, parameter
             # if there is no path from the initial marking
             # replaying the given prefix, then add None
             align_result.append(None)
+
+    # for i in range(len(fake_log)):
+    #     trace = fake_log[i]
+    #     sync_net, sync_initial_marking, sync_final_marking = build_sync_net(
+    #         trace, net, marking, final_marking, parameters=parameters
+    #     )
+    #     stop_marking = Marking()
+    #     for pl, count in sync_final_marking.items():
+    #         if pl.name[1] == utils.SKIP:
+    #             stop_marking[pl] = count
+    #     cost_function = utils.construct_standard_cost_function(sync_net, utils.SKIP)
+
+    #     # perform the alignment of the prefix
+    #     res = precision_utils.__search(
+    #         sync_net,
+    #         sync_initial_marking,
+    #         sync_final_marking,
+    #         stop_marking,
+    #         cost_function,
+    #         utils.SKIP,
+    #     )
+
+    # if res is not None:
+    #     align_result.append([])
+    #     for mark in res:
+    #         res2 = {}
+    #         for pl in mark:
+    #             # transforms the markings for easier correspondence at the end
+    #             # (distributed engine friendly!)
+    #             res2[(pl.name[0], pl.name[1])] = mark[pl]
+
+    #         align_result[-1].append(res2)
+    # else:
+    #     # if there is no path from the initial marking
+    #     # replaying the given prefix, then add None
+    #     align_result.append(None)
 
     return align_result
 
@@ -245,14 +330,22 @@ def build_sync_net(trace, petri_net, initial_marking, final_marking, parameters=
     if parameters is None:
         parameters = {}
 
-    activity_key = exec_utils.get_param_value(Parameters.ACTIVITY_KEY, parameters, xes_constants.DEFAULT_NAME_KEY)
+    activity_key = exec_utils.get_param_value(
+        Parameters.ACTIVITY_KEY, parameters, xes_constants.DEFAULT_NAME_KEY
+    )
 
-    trace_net, trace_im, trace_fm = construct_trace_net(trace, activity_key=activity_key)
+    trace_net, trace_im, trace_fm = construct_trace_net(
+        trace, activity_key=activity_key
+    )
 
-    sync_prod, sync_initial_marking, sync_final_marking = construct(trace_net, trace_im,
-                                                                                              trace_fm, petri_net,
-                                                                                              initial_marking,
-                                                                                              final_marking,
-                                                                                              utils.SKIP)
+    sync_prod, sync_initial_marking, sync_final_marking = construct(
+        trace_net,
+        trace_im,
+        trace_fm,
+        petri_net,
+        initial_marking,
+        final_marking,
+        utils.SKIP,
+    )
 
     return sync_prod, sync_initial_marking, sync_final_marking

--- a/pm4py/evaluation/replay_fitness/variants/alignment_based.py
+++ b/pm4py/evaluation/replay_fitness/variants/alignment_based.py
@@ -24,6 +24,7 @@ from pm4py.algo.conformance.alignments.algorithm import (
 )
 from pm4py.algo.conformance.decomp_alignments import algorithm as decomp_alignments
 from pm4py.evaluation.replay_fitness.parameters import Parameters
+from pm4py.objects.log.log import EventLog, Event, Trace
 from pm4py.util import exec_utils
 
 
@@ -68,8 +69,10 @@ def evaluate(aligned_traces, parameters=None):
 
 
 def wrapper(trace, net, initial_marking, final_marking, parameters):
+    log = EventLog()
+    log.append(trace)
     return apply_parallel(
-        trace,
+        log,
         petri_net=net,
         initial_marking=initial_marking,
         final_marking=final_marking,
@@ -127,17 +130,11 @@ def apply(
             parameters=parameters,
         )
         with Pool(processes=pool_size) as pool:
-            alignment_result = pool.map(partial_func, log)
+            results = pool.map(partial_func, log)
             pool.close()
             pool.join()
-        # alignment_result = alignments.apply(
-        #     log,
-        #     petri_net,
-        #     initial_marking,
-        #     final_marking,
-        #     variant=align_variant,
-        #     parameters=parameters,
-        # )
+            alignment_result = [x[0] for x in results]
+
     return evaluate(alignment_result)
 
 


### PR DESCRIPTION
Introducing parallelized fitness calculation, using multiprocessing pool of static size cpu.count() -3.

For each trace of the log, we create a new event log containing only the corresponding trace (this approach is based on the issue of alignment calculation. If alignment calculation is called with an event log, it returns the alignment including fitness. If alignment calculation is called with only one trace, only the alignment is returned).

 